### PR TITLE
Better GPU support

### DIFF
--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,0 +1,24 @@
+import tntorch as tn
+import torch
+
+# in case the computer testing has no gpu, tests will just pass
+device = 'cuda' if torch.cuda.is_available() else 'cpu' 
+
+def test_tt():
+    X = torch.randn(16,16,16)
+    y1 = tn.Tensor(X, ranks_tt=3).torch()
+    y2 =  tn.Tensor(X, ranks_tt=3, device=device).torch().cpu()
+    assert torch.abs(y1-y2).max() < 1e-5
+
+def test_tucker():
+    X = torch.randn(16,16,16)
+    y1 = tn.Tensor(X, ranks_tucker=3).torch()
+    y2 =  tn.Tensor(X, ranks_tucker=3, device=device).torch().cpu()
+    assert torch.abs(y1-y2).max() < 1e-5
+
+def test_cp():
+    X = torch.randn(16,16,16)
+    y1 = tn.Tensor(X, ranks_cp=3).torch()
+    y2 =  tn.Tensor(X, ranks_cp=3, device=device).torch().cpu()
+    assert torch.abs(y1-y2).max() < 1e-5
+

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -93,3 +93,4 @@ def test_stats():
     for i in range(100):
         t = random_format(shape)
         check()
+

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,7 +13,7 @@ def test_cat():
         t1 = tn.rand(shape1, ranks_tt=2, ranks_tucker=2)
         t2 = tn.rand(shape2, ranks_tt=2)
         gt = np.concatenate([t1.numpy(), t2.numpy()], mode)
-        assert np.linalg.norm(gt - tn.cat([t1, t2], mode).numpy()) <= 1e-7
+        assert np.linalg.norm(gt - tn.cat([t1, t2], dim=mode).numpy()) <= 1e-7
 
 
 def test_cumsum():

--- a/tntorch/metrics.py
+++ b/tntorch/metrics.py
@@ -182,9 +182,9 @@ def mean(t, dim=None, keepdim=False):
     :return: a scalar
 
     """
-
+    denom = t.shape[dim] if dim is not None else t.size
     summed = tn.sum(t, dim, keepdim)
-    return summed / summed.size
+    return summed / denom
 
 
 def var(t):

--- a/tntorch/tensor.py
+++ b/tntorch/tensor.py
@@ -9,16 +9,18 @@ def _full_rank_tt(data):  # Naive TT formatting, don't even attempt to compress
     shape = data.shape
     result = []
     N = data.dim()
-    resh = torch.reshape(torch.Tensor(data), [shape[0], -1])
+    data = torch.Tensor(data) if type(data) is not torch.Tensor else data
+    device = data.device
+    resh = torch.reshape(data, [shape[0], -1])
     for n in range(1, N):
         if resh.shape[0] < resh.shape[1]:
-            result.append(torch.reshape(torch.eye(resh.shape[0]), [resh.shape[0] // shape[n - 1],
+            result.append(torch.reshape(torch.eye(resh.shape[0]).to(device), [resh.shape[0] // shape[n - 1],
                                                                        shape[n - 1], resh.shape[0]]))
             resh = torch.reshape(resh, (resh.shape[0] * shape[n], resh.shape[1] // shape[n]))
         else:
             result.append(torch.reshape(resh, [resh.shape[0] // shape[n - 1],
                                                    shape[n - 1], resh.shape[1]]))
-            resh = torch.reshape(torch.eye(resh.shape[1]), (resh.shape[1] * shape[n], resh.shape[1] // shape[n]))
+            resh = torch.reshape(torch.eye(resh.shape[1]).to(device), (resh.shape[1] * shape[n], resh.shape[1] // shape[n]))
     result.append(torch.reshape(resh, [resh.shape[0] // shape[N - 1], shape[N - 1], 1]))
     return result
 
@@ -866,7 +868,8 @@ class Tensor(object):
         self.orthogonalize(-1)
         for mu in range(N-1, -1, -1):
             if self.Us[mu] is None:
-                self.Us[mu] = torch.eye(self.shape[mu])
+                device = self.cores[mu].device
+                self.Us[mu] = torch.eye(self.shape[mu]).to(device)
 
             # Send non-orthogonality to factor
             Q, R = torch.qr(torch.reshape(self.cores[mu].permute(0, 2, 1), [-1, self.cores[mu].shape[1]]))

--- a/tntorch/tensor.py
+++ b/tntorch/tensor.py
@@ -703,7 +703,8 @@ class Tensor(object):
 
         t = self.decompress_tucker_factors(_clone=False)
         shape = []
-        factor = torch.ones(1, self.ranks_tt[0])
+        device = t.cores[0].device
+        factor = torch.ones(1, self.ranks_tt[0]).to(device)
         for n in range(t.dim()):
             shape.append(t.cores[n].shape[-2])
             if t.cores[n].dim() == 2:  # CP core

--- a/tntorch/tools.py
+++ b/tntorch/tools.py
@@ -191,7 +191,8 @@ def sum(t, dim=None, keepdim=False):
         dim = np.arange(t.dim())
     if not hasattr(dim, '__len__'):
         dim = [dim]
-    us = [torch.ones(t.shape[d]) for d in dim]
+    device = t.cores[0].device
+    us = [torch.ones(t.shape[d]).to(device) for d in dim]
     result = tn.ttm(t, us, dim)
     if keepdim:
         return result


### PR DESCRIPTION
There were some problems with `ones` and `eye` tensors not being assigned to the right device, leading to errors when trying to use the GPU. These changes probably don't catch every possible GPU problem, but enough to use some of this repo on the GPU. Also, added some rudimentary tests to make sure the operation is the same on the GPU and CPU.

Fixed a couple other bugs I hit when running tests.